### PR TITLE
Enable Cube PT Crowding via MTCTM2.properties file

### DIFF
--- a/model-files/RunModel.bat
+++ b/model-files/RunModel.bat
@@ -387,6 +387,10 @@ if ERRORLEVEL 2 goto done
 
 IF %ITERATION% LSS %MAX_ITERATION% GOTO iteration_start
 
+:: Create the block file that controls whether the crowding functions are called during transit assignment.
+"%PYTHON_PATH%"\python.exe %BASE_SCRIPTS%\assign\transit_assign_type_set.py CTRAMP\scripts\block\transit_assign_type.block
+
+:: Run Transit Assignment
 runtpp CTRAMP\scripts\assign\TransitAssign.job
 if ERRORLEVEL 2 goto done
 

--- a/model-files/RunModel.bat
+++ b/model-files/RunModel.bat
@@ -388,7 +388,7 @@ if ERRORLEVEL 2 goto done
 IF %ITERATION% LSS %MAX_ITERATION% GOTO iteration_start
 
 :: Create the block file that controls whether the crowding functions are called during transit assignment.
-"%PYTHON_PATH%"\python.exe %BASE_SCRIPTS%\assign\transit_assign_type_set.py CTRAMP\scripts\block\transit_assign_type.block
+"%PYTHON_PATH%"\python.exe %BASE_SCRIPTS%\assign\transit_assign_set_type.py CTRAMP\runtime\mtctm2.properties CTRAMP\scripts\block\transit_assign_type.block
 
 :: Run Transit Assignment
 runtpp CTRAMP\scripts\assign\TransitAssign.job

--- a/model-files/runtime/mtctm2.properties
+++ b/model-files/runtime/mtctm2.properties
@@ -96,6 +96,17 @@ TNC.waitTime.sd =     4.1, 4.1,  4.1, 4.1, 4.1
 Taxi.waitTime.mean = 26.5, 17.3,13.3, 9.5, 5.5
 Taxi.waitTime.sd =    6.4,  6.4, 6.4, 6.4, 6.4
 WaitTimeDistribution.EndPopEmpPerSqMi = 500,2000,5000,15000,9999999999
+#Toggle and controls for managing transit crowding assignments
+transit.crowding = True
+transit.crowding.adjustlink = True
+transit.crowding.adjustwait = False
+#Cube Version > 6.4.4
+transit.crowding.advance_support = False
+transit.crowding.convergence = 0.0001
+transit.crowding.linkdf = 0.4
+transit.crowding.voldf = 0.4
+transit.crowding.waitdf = 0.4
+
 
 #Average vehicle occupancy for 3 plus by purpose. Used for generating trip tables for assignment.
 occ3plus.purpose.Work = 3.33

--- a/model-files/runtime/mtctm2.properties
+++ b/model-files/runtime/mtctm2.properties
@@ -99,11 +99,14 @@ WaitTimeDistribution.EndPopEmpPerSqMi = 500,2000,5000,15000,9999999999
 ############################################################################################################################################################################
 #
 # TRANSIT ASSIGNMENT PARAMETERS: Toggle and controls for managing Cube PT transit crowding assignments
-#
+# 
+# These properties are used to generate the Cube PT Assignment script, and are not used in the Java code.
+# A python script, transit_assign_type_set.py, reads these flags and builds a Cube block script that is read
+# in dynamically during the PT assignment process.
+# 
 # transit.crowding: Master toggle to enable adjustlink and adjustwait. 
 # transit.crowding.adjustlink: Toggle to enable link travel-time adjustment based on crowding
 # transit.crowding.adjustwait: Toggle to enable wait adjusted travel times and bump boardings from crowding
-# 
 #
 # transit.crowding.advance_support: Toggle if Cube version is > 6.4.4 and supports advanced convergence and dampening factors (df)
 # transit.crowding.convergence: Cube PT crowding RMSE congervence criteria (See Cube Documentation (Version 6.4.4 or greater))

--- a/model-files/runtime/mtctm2.properties
+++ b/model-files/runtime/mtctm2.properties
@@ -96,11 +96,25 @@ TNC.waitTime.sd =     4.1, 4.1,  4.1, 4.1, 4.1
 Taxi.waitTime.mean = 26.5, 17.3,13.3, 9.5, 5.5
 Taxi.waitTime.sd =    6.4,  6.4, 6.4, 6.4, 6.4
 WaitTimeDistribution.EndPopEmpPerSqMi = 500,2000,5000,15000,9999999999
-#Toggle and controls for managing transit crowding assignments
+############################################################################################################################################################################
+#
+# TRANSIT ASSIGNMENT PARAMETERS: Toggle and controls for managing Cube PT transit crowding assignments
+#
+# transit.crowding: Master toggle to enable adjustlink and adjustwait. 
+# transit.crowding.adjustlink: Toggle to enable link travel-time adjustment based on crowding
+# transit.crowding.adjustwait: Toggle to enable wait adjusted travel times and bump boardings from crowding
+# 
+#
+# transit.crowding.advance_support: Toggle if Cube version is > 6.4.4 and supports advanced convergence and dampening factors (df)
+# transit.crowding.convergence: Cube PT crowding RMSE congervence criteria (See Cube Documentation (Version 6.4.4 or greater))
+# transit.crowding.linkdf: Cube PT link dampening factor (See Cube Documentation (Version 6.4.4 or greater))
+# transit.crowding.voldf: Cube PT volume dampening factor (See Cube Documentation (Version 6.4.4 or greater))
+# transit.crowding.waitdf: Cube PT wait dampening factor (See Cube Documentation (Version 6.4.4 or greater))
+############################################################################################################################################################################
 transit.crowding = True
 transit.crowding.adjustlink = True
 transit.crowding.adjustwait = False
-#Cube Version > 6.4.4
+# Features below require Cube Version > 6.4.4
 transit.crowding.advance_support = False
 transit.crowding.convergence = 0.0001
 transit.crowding.linkdf = 0.4

--- a/model-files/runtime/mtctm2.properties
+++ b/model-files/runtime/mtctm2.properties
@@ -96,6 +96,7 @@ TNC.waitTime.sd =     4.1, 4.1,  4.1, 4.1, 4.1
 Taxi.waitTime.mean = 26.5, 17.3,13.3, 9.5, 5.5
 Taxi.waitTime.sd =    6.4,  6.4, 6.4, 6.4, 6.4
 WaitTimeDistribution.EndPopEmpPerSqMi = 500,2000,5000,15000,9999999999
+
 ############################################################################################################################################################################
 #
 # TRANSIT ASSIGNMENT PARAMETERS: Toggle and controls for managing Cube PT transit crowding assignments

--- a/model-files/scripts/assign/TransitAssign.job
+++ b/model-files/scripts/assign/TransitAssign.job
@@ -85,7 +85,7 @@
 ; ----------------------------------------------------------------------------------------------------------------
 
 ;start cluster nodes - one for each skim set and time period
-*Cluster.exe MTC_TRANASN 1-15 start exit
+ *Cluster.exe MTC_TRANASN 1-5 start exit
 
 ;now build transit times based on congested times from loaded network
 ;loop over time period
@@ -104,38 +104,34 @@ LOOP PERIOD = 1,5
         TOKEN_PERIOD = 'EV'
     ENDIF
     
-    LOOP SKIMSET = 1,3
-
-        ; specify SKIMSET specific stuff
-        SKIMSET_NAME = 'SET' + STR(SKIMSET,1,0)
-        counter = 3*(PERIOD - 1) + SKIMSET
+       
+    ; do each time of day and mode as a separate process
+    DistributeMultistep processid = 'MTC_TRANASN', processNum = PERIOD
+        ;make a copy of the network so that we don't walk all over each other
+        *copy hwy\mtc_transit_network_@TOKEN_PERIOD@.net trn\mtc_transit_network_@TOKEN_PERIOD@.net
         
-        ; do each time of day and mode as a separate process
-        DistributeMultistep processid = 'MTC_TRANASN', processNum = counter
-            ;make a copy of the network so that we don't walk all over each other
-            *copy hwy\mtc_transit_network_@TOKEN_PERIOD@.net trn\mtc_transit_network_@TOKEN_PERIOD@_@SKIMSET_NAME@.net
 
-            ;next, assign trips
-            RUN PGM = PUBLIC TRANSPORT
-                FILEI NETI = "trn\mtc_transit_network_@TOKEN_PERIOD@_@SKIMSET_NAME@.net"
-                FILEI LINEI[1] = "trn\transitLines_new_nodes.lin"
-                FILEI SYSTEMI = "trn\transitSystem.PTS"
-                FILEI FACTORI[1] = "trn\transitFactors_@SKIMSET_NAME@.fac"
-                
-                FILEI FAREMATI[1] = "trn\fareMatrix.txt"
-                FILEI FAREI= "trn\fares.far"
-                
-                FILEI MATI[1] = "ctramp_output\TAP_Demand_set@SKIMSET@_@TOKEN_PERIOD@.mat"
-                
-                FILEO NETO = "trn\mtc_transit_network_@TOKEN_PERIOD@_@SKIMSET_NAME@_with_transit_assign.net"
-
-                ; These files are gigantic and writing many simultaneously cause PT to fail
-                ; with the message: F(801): (EnumRoutes) Failure writing to output routes file.
-                ; We cannot comment them out, however, since 
-                ; "The statement ROUTEO[x] invokes the route-enumeration process for user class x." (!!)
-                ; FILEO ROUTEO[1] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_@SKIMSET_NAME@_with_transit_assign.rte"
-
-                FILEO REPORTO = "trn\mtc_transit_report_@TOKEN_PERIOD@_@SKIMSET_NAME@_with_transit_assign.rpt"
+        ;next, assign trips
+        RUN PGM = PUBLIC TRANSPORT
+            FILEI NETI = "trn\mtc_transit_network_@TOKEN_PERIOD@.net"
+            FILEI LINEI[1] = "trn\transitLines_new_nodes_veh.lin"
+            FILEI SYSTEMI = "trn\transitSystem_new.PTS"
+            FILEI FACTORI[1] = "trn\transitFactors_SET1.fac"
+            FILEI FACTORI[2] = "trn\transitFactors_SET3.fac"
+            FILEI FACTORI[3] = "trn\transitFactors_SET3.fac"
+            
+            FILEI FAREMATI[1] = "trn\fareMatrix.txt"
+            FILEI FAREI= "trn\fares.far"
+            
+            FILEI MATI[1] = "ctramp_output\TAP_Demand_set1_@TOKEN_PERIOD@.mat"
+            FILEI MATI[2] = "ctramp_output\TAP_Demand_set2_@TOKEN_PERIOD@.mat"
+            FILEI MATI[3] = "ctramp_output\TAP_Demand_set3_@TOKEN_PERIOD@.mat"
+            
+            FILEO NETO = "trn\mtc_transit_network_@TOKEN_PERIOD@_with_transit_assign.net"
+            FILEO ROUTEO[1] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET1_with_transit_assign.rte"
+            FILEO ROUTEO[2] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET2_with_transit_assign.rte"
+            FILEO ROUTEO[3] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET3_with_transit_assign.rte"
+            FILEO REPORTO = "trn\mtc_transit_report_@TOKEN_PERIOD@_with_transit_assign.rpt"
                 ;
                 ; The stop2stop file is for BART station-station boardings. It writes a dbf file of boardings 
                 : by station pair for the listed station nodes. Note that node numbers change for each network
@@ -143,51 +139,52 @@ LOOP PERIOD = 1,5
                 ; network used for calibration\validation. TODO: automate process for creating node list.
                 ;
                 FILEO STOP2STOPO = "trn\mtc_stop2stop_@TOKEN_PERIOD@_@SKIMSET_NAME@.dbf", ACCUMULATE=FIRSTLASTBYMODE, MODES=120, NODES=1083175,1083190,1083193,1083233,1083275,1083398,1083401,1083492,1129772,1129773,1129776,1129777,1129778,1129786,1314178,1338535,1338536,1338537,1338540,1338543,1338545,1338546,1338547,1338549,1338552,1338553,1338554,1338555,1338557,1338559,1338561,1338563,1338564,1338565,1338566,1419864,1419865,1419866,1419867,1419868,1419869,1419870,1419872,1419873,1419874
-                
-                PARAMETERS HDWAYPERIOD=@PERIOD@
-                PARAMETERS NOROUTEERRS=17000000
-                PARAMETERS TRANTIME=LI.TRANTIME
-                PARAMETERS MAPSCALE=5280
-                                
-                PROCESS PHASE=LINKREAD
-                    LW.TRANTIME = LI.TRANTIME
-                    LW.DISTANCE = LI.FEET/5280
-                ENDPROCESS
-                
-                PHASE=DATAPREP
-                    ;access/egress links
-                    GENERATE,       
-                        NTLEGMODE=991,
-                        INCLUDELINK=(LI.NTL_MODE=1),
-                        COST=LI.WALKTIME,
-                        MAXCOST=999*500,
-                        ONEWAY=T
-                    ;transfer links
-                    GENERATE,
-                        NTLEGMODE=992,       
-                        INCLUDELINK=(LI.NTL_MODE=2),
-                        COST=LI.WALKTIME,
-                        MAXCOST=999*500,
-                        DIRECTLINK = 3,
-                        FROMNODE=1-10000000,
-                        TONODE=1-10000000
-                ENDPHASE
-                
-                PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
-                
-                REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
-                
-            ENDRUN
+            
+            PARAMETERS HDWAYPERIOD=@PERIOD@
+            PARAMETERS NOROUTEERRS=17000000
+            PARAMETERS TRANTIME=LI.TRANTIME
+            PARAMETERS MAPSCALE=5280
+            PARAMETERS USERCLASSES=1,2,3
+                            
+            PROCESS PHASE=LINKREAD
+                LW.TRANTIME = LI.TRANTIME
+                LW.DISTANCE = LI.FEET/5280
+            ENDPROCESS
+            
+            PHASE=DATAPREP
+                ;access/egress links
+                GENERATE,       
+                    NTLEGMODE=991,
+                    INCLUDELINK=(LI.NTL_MODE=1),
+                    COST=LI.WALKTIME,
+                    MAXCOST=999*500,
+                    ONEWAY=T
+                ;transfer links
+                GENERATE,
+                    NTLEGMODE=992,       
+                    INCLUDELINK=(LI.NTL_MODE=2),
+                    COST=LI.WALKTIME,
+                    MAXCOST=999*500,
+                    DIRECTLINK = 3,
+                    FROMNODE=1-10000000,
+                    TONODE=1-10000000
+            ENDPHASE
+            
+            PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
+            PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
+            PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
+            
+            REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
+            
+        ENDRUN
 
-        EndDistributeMultistep
+    EndDistributeMultistep
 
-    ENDLOOP
 ENDLOOP
 
-Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, MTC_TRANASN4.script.end, MTC_TRANASN5.script.end,
-                   MTC_TRANASN6.script.end, MTC_TRANASN7.script.end, MTC_TRANASN8.script.end, MTC_TRANASN9.script.end, MTC_TRANASN10.script.end,
-                   MTC_TRANASN11.script.end, MTC_TRANASN12.script.end, MTC_TRANASN13.script.end, MTC_TRANASN14.script.end, MTC_TRANASN15.script.end,
-           printfiles = merge, deldistribfiles = t, CheckReturnCode = t
+Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, 
+                   MTC_TRANASN4.script.end, MTC_TRANASN5.script.end, 
+                   printfiles = merge, deldistribfiles = t, CheckReturnCode = t
 
 ;stop cluster nodes
-*Cluster.exe MTC_TRANASN 1-15 close exit
+*Cluster.exe MTC_TRANASN 1-5 close exit

--- a/model-files/scripts/assign/TransitAssign.job
+++ b/model-files/scripts/assign/TransitAssign.job
@@ -117,7 +117,7 @@ LOOP PERIOD = 1,5
             FILEI LINEI[1] = "trn\transitLines_new_nodes_veh.lin"
             FILEI SYSTEMI = "trn\transitSystem_new.PTS"
             FILEI FACTORI[1] = "trn\transitFactors_SET1.fac"
-            FILEI FACTORI[2] = "trn\transitFactors_SET3.fac"
+            FILEI FACTORI[2] = "trn\transitFactors_SET2.fac"
             FILEI FACTORI[3] = "trn\transitFactors_SET3.fac"
             
             FILEI FAREMATI[1] = "trn\fareMatrix.txt"

--- a/model-files/scripts/assign/TransitAssign.job
+++ b/model-files/scripts/assign/TransitAssign.job
@@ -111,7 +111,7 @@ LOOP PERIOD = 1,5
     
        
     ; do each time of day and mode as a separate process
-     DistributeMultistep processid = 'MTC_TRANASN', processNum = PERIOD
+    DistributeMultistep processid = 'MTC_TRANASN', processNum = PERIOD
         ;make a copy of the network so that we don't walk all over each other
         *copy hwy\mtc_transit_network_@TOKEN_PERIOD@.net trn\mtc_transit_network_@TOKEN_PERIOD@.net
         
@@ -151,7 +151,7 @@ LOOP PERIOD = 1,5
             PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
             PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
             PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
-            
+                            
             PROCESS PHASE=LINKREAD
                 LW.TRANTIME = LI.TRANTIME
                 LW.DISTANCE = LI.FEET/5280
@@ -176,21 +176,24 @@ LOOP PERIOD = 1,5
                     TONODE=1-10000000
             ENDPHASE
             
+            PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
+            PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
+            PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
             
-            
+            REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
             CROWDMODEL APPLY=T, ADJUSTLINK=T, ADJUSTWAIT=T, ITERATIONS=10, PERIOD=@PERIOD_DURATION@, REPORTIJ=T, 
                        TRACEIJ=T, RDIFF=T, RMSE=T, STOP2STOP=T, SKIMS=T
             ;REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
             
         ENDRUN
 
-      EndDistributeMultistep
+    EndDistributeMultistep
 
 ENDLOOP
 
- Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, 
-                    MTC_TRANASN4.script.end, MTC_TRANASN5.script.end, CheckReturnCode = t
-                    ;printfiles = merge, deldistribfiles = t, CheckReturnCode = t
+Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, 
+                   MTC_TRANASN4.script.end, MTC_TRANASN5.script.end, 
+                   printfiles = merge, deldistribfiles = t, CheckReturnCode = t
 
 ;stop cluster nodes
 *Cluster.exe MTC_TRANASN 1-5 close exit

--- a/model-files/scripts/assign/TransitAssign.job
+++ b/model-files/scripts/assign/TransitAssign.job
@@ -84,6 +84,8 @@
 ; author: sn(11/7/2014)
 ; ----------------------------------------------------------------------------------------------------------------
 
+CROWDING_SKIM_BLOCK = '%BASE_SCRIPTS%\block\transit_assign_type.block'
+
 ;start cluster nodes - one for each skim set and time period
 *Cluster.exe MTC_TRANASN 1-5 start exit
 
@@ -189,24 +191,8 @@ LOOP PERIOD = 1,5
             
             REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
             
-            CROWDMODEL APPLY=T, ADJUSTLINK=T, ADJUSTWAIT=F, ITERATIONS=10, PERIOD=@PERIOD_DURATION@,
-                   RDIFF=T, RMSE=T, STOP2STOP=T, SKIMS=T, LINKDF=0.6, VOLDF=0.6, WAITDF=0.6, RMSESTOP=T, RMSECUTOFF=0.00001
-            
-            PHASE=SKIMIJ
-                MW[1] = CWDWAITA(0)
-                MW[2] = IWAITA(0)
-                MW[3] = XWAITA(0)
-                MW[4] = CWDWAITP(0)
-                MW[5] = IWAITP(0)
-                MW[6] = XWAITP(0)
-                MW[7] = TIMEA(0,ALLMODES)
-                MW[8] = CWDCOSTP(0,ALLMODES)
-                MW[9] = TIMEP(0,ALLMODES)
-                MW[10] = EXCESSDEMAND
-                MW[11] = EXCESSPROP
-                MW[12] = COMPCOST(0)
-            ENDPHASE
-            
+			READ FILE = @CROWDING_SKIM_BLOCK@
+			
         ENDRUN
 
     EndDistributeMultistep

--- a/model-files/scripts/assign/TransitAssign.job
+++ b/model-files/scripts/assign/TransitAssign.job
@@ -111,7 +111,7 @@ LOOP PERIOD = 1,5
     
        
     ; do each time of day and mode as a separate process
-    DistributeMultistep processid = 'MTC_TRANASN', processNum = PERIOD
+     DistributeMultistep processid = 'MTC_TRANASN', processNum = PERIOD
         ;make a copy of the network so that we don't walk all over each other
         *copy hwy\mtc_transit_network_@TOKEN_PERIOD@.net trn\mtc_transit_network_@TOKEN_PERIOD@.net
         
@@ -151,7 +151,7 @@ LOOP PERIOD = 1,5
             PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
             PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
             PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
-                            
+            
             PROCESS PHASE=LINKREAD
                 LW.TRANTIME = LI.TRANTIME
                 LW.DISTANCE = LI.FEET/5280
@@ -176,24 +176,21 @@ LOOP PERIOD = 1,5
                     TONODE=1-10000000
             ENDPHASE
             
-            PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
-            PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
-            PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
             
-            REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
+            
             CROWDMODEL APPLY=T, ADJUSTLINK=T, ADJUSTWAIT=T, ITERATIONS=10, PERIOD=@PERIOD_DURATION@, REPORTIJ=T, 
                        TRACEIJ=T, RDIFF=T, RMSE=T, STOP2STOP=T, SKIMS=T
             ;REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
             
         ENDRUN
 
-    EndDistributeMultistep
+      EndDistributeMultistep
 
 ENDLOOP
 
-Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, 
-                   MTC_TRANASN4.script.end, MTC_TRANASN5.script.end, 
-                   printfiles = merge, deldistribfiles = t, CheckReturnCode = t
+ Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, 
+                    MTC_TRANASN4.script.end, MTC_TRANASN5.script.end, CheckReturnCode = t
+                    ;printfiles = merge, deldistribfiles = t, CheckReturnCode = t
 
 ;stop cluster nodes
 *Cluster.exe MTC_TRANASN 1-5 close exit

--- a/model-files/scripts/assign/TransitAssign.job
+++ b/model-files/scripts/assign/TransitAssign.job
@@ -136,9 +136,10 @@ LOOP PERIOD = 1,5
             
             FILEO NETO = "trn\mtc_transit_network_@TOKEN_PERIOD@_with_transit_assign.net"
             
-            FILEO ROUTEO[1] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET1_with_transit_assign.rte"
-            FILEO ROUTEO[2] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET2_with_transit_assign.rte"
-            FILEO ROUTEO[3] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET3_with_transit_assign.rte"
+            ; Turning off Route Enumeration output for now to save space and run time.
+            ;FILEO ROUTEO[1] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET1_with_transit_assign.rte"
+            ;FILEO ROUTEO[2] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET2_with_transit_assign.rte"
+            ;FILEO ROUTEO[3] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET3_with_transit_assign.rte"
             
             FILEO MATO[1] = "trn\PTSKIMS_set1_@TOKEN_PERIOD@.MAT" MO=1-12 NAME=CWDWAITA, IWAITA, XWAITA, CWDWAITP, IWAITP, XWAITP, TIMEA, CWDCOSTP, TIMEP, EXCESSDEMAND, EXCESSPROP, COMPCOST
             FILEO MATO[2] = "trn\PTSKIMS_set2_@TOKEN_PERIOD@.MAT" MO=1-12 NAME=CWDWAITA, IWAITA, XWAITA, CWDWAITP, IWAITP, XWAITP, TIMEA, CWDCOSTP, TIMEP, EXCESSDEMAND, EXCESSPROP, COMPCOST

--- a/model-files/scripts/assign/TransitAssign.job
+++ b/model-files/scripts/assign/TransitAssign.job
@@ -109,17 +109,17 @@ LOOP PERIOD = 1,5
         PERIOD_DURATION = 480
     ENDIF
     
-       
+    counter = PERIOD
+        
     ; do each time of day and mode as a separate process
-     DistributeMultistep processid = 'MTC_TRANASN', processNum = PERIOD
+    DistributeMultistep processid = 'MTC_TRANASN', processNum = counter
         ;make a copy of the network so that we don't walk all over each other
         *copy hwy\mtc_transit_network_@TOKEN_PERIOD@.net trn\mtc_transit_network_@TOKEN_PERIOD@.net
-        
 
         ;next, assign trips
-        RUN PGM = PUBLIC TRANSPORT
+        RUN PGM = PUBLIC TRANSPORT PRNFILE="TRANSIT_ASSIGN.prn"
             FILEI NETI = "trn\mtc_transit_network_@TOKEN_PERIOD@.net"
-            FILEI LINEI[1] = "trn\transitLines_new_nodes_veh.lin"
+            FILEI LINEI[1] = "trn\transitLines_new_nodes.lin"
             FILEI SYSTEMI = "trn\transitSystem.PTS"
             FILEI FACTORI[1] = "trn\transitFactors_SET1.fac"
             FILEI FACTORI[2] = "trn\transitFactors_SET2.fac"
@@ -133,25 +133,32 @@ LOOP PERIOD = 1,5
             FILEI MATI[3] = "ctramp_output\TAP_Demand_set3_@TOKEN_PERIOD@.mat"
             
             FILEO NETO = "trn\mtc_transit_network_@TOKEN_PERIOD@_with_transit_assign.net"
+            
             FILEO ROUTEO[1] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET1_with_transit_assign.rte"
             FILEO ROUTEO[2] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET2_with_transit_assign.rte"
             FILEO ROUTEO[3] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET3_with_transit_assign.rte"
+            
+            FILEO MATO[1] = "trn\PTSKIMS_set1_@TOKEN_PERIOD@.MAT" MO=1-12 NAME=CWDWAITA, IWAITA, XWAITA, CWDWAITP, IWAITP, XWAITP, TIMEA, CWDCOSTP, TIMEP, EXCESSDEMAND, EXCESSPROP, COMPCOST
+            FILEO MATO[2] = "trn\PTSKIMS_set2_@TOKEN_PERIOD@.MAT" MO=1-12 NAME=CWDWAITA, IWAITA, XWAITA, CWDWAITP, IWAITP, XWAITP, TIMEA, CWDCOSTP, TIMEP, EXCESSDEMAND, EXCESSPROP, COMPCOST
+            FILEO MATO[3] = "trn\PTSKIMS_set3_@TOKEN_PERIOD@.MAT" MO=1-12 NAME=CWDWAITA, IWAITA, XWAITA, CWDWAITP, IWAITP, XWAITP, TIMEA, CWDCOSTP, TIMEP, EXCESSDEMAND, EXCESSPROP, COMPCOST
+            
+            
             FILEO REPORTO = "trn\mtc_transit_report_@TOKEN_PERIOD@_with_transit_assign.rpt"
-            FILEO STOP2STOPO = "trn\STOP2STOP.DBF" ACCUMULATE=FIRSTLAST FORMAT=CSV N=1338552,1338536,1338561,1338565,1338554,1338543,1338547,1338559,1338563,1338564,1083492,1083398,1083193,1083233,1083401,1083175,1083275,1083190,1129772
-            FILEO MATO[1] = "trn\PTSKIMS_set1_@TOKEN_PERIOD@.MAT" MO=1-5 NAME=CWDWAITA,CWDWAITP,CWDCOSTP,IWAITA,IWAITP
-            FILEO MATO[2] = "trn\PTSKIMS_set2_@TOKEN_PERIOD@.MAT" MO=1-5 NAME=CWDWAITA,CWDWAITP,CWDCOSTP,IWAITA,IWAITP
-            FILEO MATO[3] = "trn\PTSKIMS_set3_@TOKEN_PERIOD@.MAT" MO=1-5 NAME=CWDWAITA,CWDWAITP,CWDCOSTP,IWAITA,IWAITP
+            ;
+            ; The stop2stop file is for BART station-station boardings. It writes a dbf file of boardings 
+            : by station pair for the listed station nodes. Note that node numbers change for each network
+            ; due to changes in node sequencing. The list below is specific to the version of the 2015
+            ; network used for calibration\validation. TODO: automate process for creating node list.
+            ;
+            FILEO STOP2STOPO = "trn\mtc_stop2stop_@TOKEN_PERIOD@.dbf", ACCUMULATE=FIRSTLASTBYMODE, MODES=120, NODES=1083175,1083190,1083193,1083233,1083275,1083398,1083401,1083492,1129772,1129773,1129776,1129777,1129778,1129786,1314178,1338535,1338536,1338537,1338540,1338543,1338545,1338546,1338547,1338549,1338552,1338553,1338554,1338555,1338557,1338559,1338561,1338563,1338564,1338565,1338566,1419864,1419865,1419866,1419867,1419868,1419869,1419870,1419872,1419873,1419874
+
             
             PARAMETERS HDWAYPERIOD=@PERIOD@
             PARAMETERS NOROUTEERRS=17000000
             PARAMETERS TRANTIME=LI.TRANTIME
             PARAMETERS MAPSCALE=5280
             PARAMETERS USERCLASSES=1,2,3
-            
-            PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
-            PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
-            PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
-            
+                            
             PROCESS PHASE=LINKREAD
                 LW.TRANTIME = LI.TRANTIME
                 LW.DISTANCE = LI.FEET/5280
@@ -176,21 +183,38 @@ LOOP PERIOD = 1,5
                     TONODE=1-10000000
             ENDPHASE
             
+            PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
+            PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
+            PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
             
+            REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
             
-            CROWDMODEL APPLY=T, ADJUSTLINK=T, ADJUSTWAIT=T, ITERATIONS=10, PERIOD=@PERIOD_DURATION@, REPORTIJ=T, 
-                       TRACEIJ=T, RDIFF=T, RMSE=T, STOP2STOP=T, SKIMS=T
-            ;REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
+            CROWDMODEL APPLY=T, ADJUSTLINK=T, ADJUSTWAIT=F, ITERATIONS=10, PERIOD=@PERIOD_DURATION@,
+                   RDIFF=T, RMSE=T, STOP2STOP=T, SKIMS=T, LINKDF=0.6, VOLDF=0.6, WAITDF=0.6, RMSESTOP=T, RMSECUTOFF=0.00001
+            
+            PHASE=SKIMIJ
+                MW[1] = CWDWAITA(0)
+                MW[2] = IWAITA(0)
+                MW[3] = XWAITA(0)
+                MW[4] = CWDWAITP(0)
+                MW[5] = IWAITP(0)
+                MW[6] = XWAITP(0)
+                MW[7] = TIMEA(0,ALLMODES)
+                MW[8] = CWDCOSTP(0,ALLMODES)
+                MW[9] = TIMEP(0,ALLMODES)
+                MW[10] = EXCESSDEMAND
+                MW[11] = EXCESSPROP
+                MW[12] = COMPCOST(0)
+            ENDPHASE
             
         ENDRUN
 
-      EndDistributeMultistep
+    EndDistributeMultistep
 
 ENDLOOP
 
- Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, 
-                    MTC_TRANASN4.script.end, MTC_TRANASN5.script.end, CheckReturnCode = t
-                    ;printfiles = merge, deldistribfiles = t, CheckReturnCode = t
+Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, MTC_TRANASN4.script.end, MTC_TRANASN5.script.end,
+                   printfiles = merge, deldistribfiles = t, CheckReturnCode = t
 
 ;stop cluster nodes
 *Cluster.exe MTC_TRANASN 1-5 close exit

--- a/model-files/scripts/assign/TransitAssign.job
+++ b/model-files/scripts/assign/TransitAssign.job
@@ -85,7 +85,7 @@
 ; ----------------------------------------------------------------------------------------------------------------
 
 ;start cluster nodes - one for each skim set and time period
- *Cluster.exe MTC_TRANASN 1-5 start exit
+*Cluster.exe MTC_TRANASN 1-5 start exit
 
 ;now build transit times based on congested times from loaded network
 ;loop over time period
@@ -94,19 +94,24 @@ LOOP PERIOD = 1,5
     ; a two letter token is used for each time period
     IF (PERIOD = 1)   
         TOKEN_PERIOD = 'EA' 
+        PERIOD_DURATION = 180
     ELSEIF (PERIOD = 2)   
         TOKEN_PERIOD = 'AM' 
+        PERIOD_DURATION = 240
     ELSEIF (PERIOD = 3)   
         TOKEN_PERIOD = 'MD' 
+        PERIOD_DURATION = 300
     ELSEIF (PERIOD = 4)   
         TOKEN_PERIOD = 'PM'
+        PERIOD_DURATION = 240
     ELSEIF (PERIOD = 5)   
         TOKEN_PERIOD = 'EV'
+        PERIOD_DURATION = 480
     ENDIF
     
        
     ; do each time of day and mode as a separate process
-    DistributeMultistep processid = 'MTC_TRANASN', processNum = PERIOD
+     DistributeMultistep processid = 'MTC_TRANASN', processNum = PERIOD
         ;make a copy of the network so that we don't walk all over each other
         *copy hwy\mtc_transit_network_@TOKEN_PERIOD@.net trn\mtc_transit_network_@TOKEN_PERIOD@.net
         
@@ -115,7 +120,7 @@ LOOP PERIOD = 1,5
         RUN PGM = PUBLIC TRANSPORT
             FILEI NETI = "trn\mtc_transit_network_@TOKEN_PERIOD@.net"
             FILEI LINEI[1] = "trn\transitLines_new_nodes_veh.lin"
-            FILEI SYSTEMI = "trn\transitSystem_new.PTS"
+            FILEI SYSTEMI = "trn\transitSystem.PTS"
             FILEI FACTORI[1] = "trn\transitFactors_SET1.fac"
             FILEI FACTORI[2] = "trn\transitFactors_SET2.fac"
             FILEI FACTORI[3] = "trn\transitFactors_SET3.fac"
@@ -132,20 +137,21 @@ LOOP PERIOD = 1,5
             FILEO ROUTEO[2] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET2_with_transit_assign.rte"
             FILEO ROUTEO[3] = "trn\mtc_transit_routes_@TOKEN_PERIOD@_SET3_with_transit_assign.rte"
             FILEO REPORTO = "trn\mtc_transit_report_@TOKEN_PERIOD@_with_transit_assign.rpt"
-                ;
-                ; The stop2stop file is for BART station-station boardings. It writes a dbf file of boardings 
-                : by station pair for the listed station nodes. Note that node numbers change for each network
-                ; due to changes in node sequencing. The list below is specific to the version of the 2015
-                ; network used for calibration\validation. TODO: automate process for creating node list.
-                ;
-                FILEO STOP2STOPO = "trn\mtc_stop2stop_@TOKEN_PERIOD@_@SKIMSET_NAME@.dbf", ACCUMULATE=FIRSTLASTBYMODE, MODES=120, NODES=1083175,1083190,1083193,1083233,1083275,1083398,1083401,1083492,1129772,1129773,1129776,1129777,1129778,1129786,1314178,1338535,1338536,1338537,1338540,1338543,1338545,1338546,1338547,1338549,1338552,1338553,1338554,1338555,1338557,1338559,1338561,1338563,1338564,1338565,1338566,1419864,1419865,1419866,1419867,1419868,1419869,1419870,1419872,1419873,1419874
+            FILEO STOP2STOPO = "trn\STOP2STOP.DBF" ACCUMULATE=FIRSTLAST FORMAT=CSV N=1338552,1338536,1338561,1338565,1338554,1338543,1338547,1338559,1338563,1338564,1083492,1083398,1083193,1083233,1083401,1083175,1083275,1083190,1129772
+            FILEO MATO[1] = "trn\PTSKIMS_set1_@TOKEN_PERIOD@.MAT" MO=1-5 NAME=CWDWAITA,CWDWAITP,CWDCOSTP,IWAITA,IWAITP
+            FILEO MATO[2] = "trn\PTSKIMS_set2_@TOKEN_PERIOD@.MAT" MO=1-5 NAME=CWDWAITA,CWDWAITP,CWDCOSTP,IWAITA,IWAITP
+            FILEO MATO[3] = "trn\PTSKIMS_set3_@TOKEN_PERIOD@.MAT" MO=1-5 NAME=CWDWAITA,CWDWAITP,CWDCOSTP,IWAITA,IWAITP
             
             PARAMETERS HDWAYPERIOD=@PERIOD@
             PARAMETERS NOROUTEERRS=17000000
             PARAMETERS TRANTIME=LI.TRANTIME
             PARAMETERS MAPSCALE=5280
             PARAMETERS USERCLASSES=1,2,3
-                            
+            
+            PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
+            PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
+            PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
+            
             PROCESS PHASE=LINKREAD
                 LW.TRANTIME = LI.TRANTIME
                 LW.DISTANCE = LI.FEET/5280
@@ -170,21 +176,21 @@ LOOP PERIOD = 1,5
                     TONODE=1-10000000
             ENDPHASE
             
-            PARAMETERS TRIPSIJ[1] = MI.1.1 + MI.1.2 + MI.1.3 ;WLK, PNR, KNR
-            PARAMETERS TRIPSIJ[2] = MI.2.1 + MI.2.2 + MI.2.3 ;WLK, PNR, KNR
-            PARAMETERS TRIPSIJ[3] = MI.3.1 + MI.3.2 + MI.3.3 ;WLK, PNR, KNR
             
-            REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
+            
+            CROWDMODEL APPLY=T, ADJUSTLINK=T, ADJUSTWAIT=T, ITERATIONS=10, PERIOD=@PERIOD_DURATION@, REPORTIJ=T, 
+                       TRACEIJ=T, RDIFF=T, RMSE=T, STOP2STOP=T, SKIMS=T
+            ;REPORT LINES=T, SORT=MODE, LINEVOLS=T, STOPSONLY=T, SKIP0=T
             
         ENDRUN
 
-    EndDistributeMultistep
+      EndDistributeMultistep
 
 ENDLOOP
 
-Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, 
-                   MTC_TRANASN4.script.end, MTC_TRANASN5.script.end, 
-                   printfiles = merge, deldistribfiles = t, CheckReturnCode = t
+ Wait4Files files = MTC_TRANASN1.script.end, MTC_TRANASN2.script.end, MTC_TRANASN3.script.end, 
+                    MTC_TRANASN4.script.end, MTC_TRANASN5.script.end, CheckReturnCode = t
+                    ;printfiles = merge, deldistribfiles = t, CheckReturnCode = t
 
 ;stop cluster nodes
 *Cluster.exe MTC_TRANASN 1-5 close exit

--- a/model-files/scripts/assign/transit_assign_set_type.py
+++ b/model-files/scripts/assign/transit_assign_set_type.py
@@ -1,6 +1,6 @@
 '''
 Python Script to build a Cube Voyager block script that determines
-whether the transit assignment will be run with or without assignment.
+whether the transit assignment will be run with or without crowding during assignment.
 
 If the program cannot find the key/value pairs in the properties file, the
 program will generate a code block with crowding disabled.

--- a/model-files/scripts/assign/transit_assign_set_type.py
+++ b/model-files/scripts/assign/transit_assign_set_type.py
@@ -1,0 +1,91 @@
+'''
+Python Script to build a Cube Voyager block script that determines
+whether the transit assignment will be run with or without assignment.
+
+If the program cannot find the key/value pairs in the properties file, the
+program will generate a code block with crowding disabled.
+
+Input:
+
+(1): Properties File
+(2): Output location for the Cube Voyager Block
+
+Ex. Usage:
+transit_assign_set_type.py CTRAMP\runtime\mtctm2.properties CTRAMP\scripts\block\transit_assign_type.block
+'''
+
+import ConfigParser
+import os
+import StringIO
+import sys
+
+properties_file = sys.argv[1]
+output_file = sys.argv[2]
+
+#Set defaults in case values are not in properties file.
+config = ConfigParser.RawConfigParser(defaults= {
+    'transit.crowding': 'False',
+    'transit.crowding.adjustlink': 'True',
+    'transit.crowding.adjustwait': 'False',
+    'transit.crowding.advance_support': 'False',
+    'transit.crowding.convergence': 0.0001,
+    'transit.crowding.linkdf': 0.4,
+    'transit.crowding.voldf': 0.4,
+    'transit.crowding.waitdf': 0.4,
+})
+
+# This is a patch (workaround), so Python can read a straight Java properties file.
+configIO = StringIO.StringIO()
+configIO.write('[defaults]\n')
+configIO.write(open(properties_file).read())
+configIO.seek(0, os.SEEK_SET)
+
+config.readfp(configIO)
+
+crowding_config = {}
+
+# Read in values
+crowding_config['enabled'] = config.getboolean('defaults','transit.crowding')
+crowding_config['adjustlink'] = config.getboolean('defaults','transit.crowding.adjustlink')
+crowding_config['adjustwait'] = config.getboolean('defaults','transit.crowding.adjustwait')
+
+crowding_config['advanced'] = config.getboolean('defaults','transit.crowding.advance_support')
+crowding_config['converge'] = config.getfloat('defaults', 'transit.crowding.convergence')
+crowding_config['linkdf'] = config.getfloat('defaults', 'transit.crowding.linkdf')
+crowding_config['voldf'] = config.getfloat('defaults', 'transit.crowding.voldf')
+crowding_config['waitdf'] = config.getfloat('defaults', 'transit.crowding.waitdf')
+
+
+crowding_line = 'CROWDMODEL APPLY=T, ADJUSTLINK={}, ADJUSTWAIT={}, ITERATIONS=10, PERIOD=@PERIOD_DURATION@, RDIFF=T, RMSE=T, STOP2STOP=T, SKIMS=T'.format(
+        'T' if crowding_config['adjustlink'] else 'F',
+        'T' if crowding_config['adjustwait'] else 'F'
+)
+crowd_convergence = '    LINKDF={linkdf:.5f}, VOLDF={voldf:.5f}, WAITDF={waitdf:.5f}, RMSESTOP=T, RMSECUTOFF={converge:.10f}'.format(**crowding_config)
+
+skims = {
+    1: {'skim_arg': 'CWDWAITA(0)', 'crowding_skim': True},
+    2: {'skim_arg': 'IWAITA(0)', 'crowding_skim': False},
+    3: {'skim_arg': 'XWAITA(0)', 'crowding_skim': False},
+    4: {'skim_arg': 'CWDWAITP(0)', 'crowding_skim': True},
+    5: {'skim_arg': 'IWAITP(0)', 'crowding_skim': False},
+    6: {'skim_arg': 'XWAITP(0)', 'crowding_skim': False},
+    7: {'skim_arg': 'TIMEA(0,ALLMODES)', 'crowding_skim': False},
+    8: {'skim_arg': 'CWDCOSTP(0,ALLMODES)', 'crowding_skim': True},
+    9: {'skim_arg': 'TIMEP(0,ALLMODES)', 'crowding_skim': False},
+    10: {'skim_arg': 'EXCESSDEMAND', 'crowding_skim': True},
+    11: {'skim_arg': 'EXCESSPROP', 'crowding_skim': True},
+    12: {'skim_arg': 'COMPCOST(0)', 'crowding_skim': False},
+}
+
+with open(output_file, 'w') as f:
+    if crowding_config['enabled']:
+        f.write(crowding_line + '\n')
+        if crowding_config['advanced']:
+            f.write(crowd_convergence + '\n')
+    
+    f.write('\nPHASE=SKIMIJ\n')
+    for idx, skim in skims.iteritems():
+        if (skim['crowding_skim'] & crowding_config['enabled']) | (not skim['crowding_skim']):
+            f.write('    MW[{}] = {}\n'.format(idx, skim['skim_arg']))
+    f.write('ENDPHASE\n')
+ 


### PR DESCRIPTION
This is a redo of pull request (https://github.com/BayAreaMetro/travel-model-two/pull/25) from @danielsclint since that one became cluttered by the update of the develop branch

This code enables the Cube PT crowding functionality via the mtctm2.properties files.

The new keys are:

#Toggle and controls for managing transit crowding assignments
transit.crowding = True
transit.crowding.adjustlink = True
transit.crowding.adjustwait = False
#Cube Version > 6.4.4
transit.crowding.advance_support = False
transit.crowding.convergence = 0.0001
transit.crowding.linkdf = 0.4
transit.crowding.voldf = 0.4
transit.crowding.waitdf = 0.4
If Cube Version > 6.4.4, additional controls related to crowding can also be toggled on/off and set to specific values.