### PR TITLE
Hotfix: Missing Comma when Building Advanced Transit Crowding Block.

### DIFF
--- a/model-files/scripts/assign/transit_assign_set_type.py
+++ b/model-files/scripts/assign/transit_assign_set_type.py
@@ -79,9 +79,11 @@ skims = {
 
 with open(output_file, 'w') as f:
     if crowding_config['enabled']:
-        f.write(crowding_line + '\n')
+        f.write(crowding_line)
         if crowding_config['advanced']:
-            f.write(crowd_convergence + '\n')
+            f.write(',\n' + crowd_convergence + '\n')
+        else:
+		    f.write('\n')
     
     f.write('\nPHASE=SKIMIJ\n')
     for idx, skim in skims.iteritems():


### PR DESCRIPTION
Add a comma to the end of the line when advanced features are enabled.